### PR TITLE
Load model from local env var path

### DIFF
--- a/thampi/core/thampi_core.py
+++ b/thampi/core/thampi_core.py
@@ -9,6 +9,7 @@ class Thampi(object):
         self.app = app
         self.project_name = os.environ['PROJECT']
         self.environment = os.environ['STAGE']
+        self.local_model_path = os.environ['LOCAL_MODEL_PATH']
         self.bucket = helper.get_bucket(self.environment)
         self.model_key = helper.model_key(self.environment, self.project_name)
         self.properties_key = helper.properties_key(self.environment, self.project_name)
@@ -16,9 +17,21 @@ class Thampi(object):
         self._context = ThampiContext(self.app)
 
     def load_model(self):
-        model = aws.load_s3_object(self.bucket, self.model_key)
+        model = None
+        if self.local_model_path:
+            model = util.load_local_model(self.local_model_path, constants.MODEL_FILE)
+        else:
+            model = aws.load_s3_object(self.bucket, self.model_key)
         model.initialize(ThampiContext(self.app))
         return model
+
+    def load_properties(self):
+        result = None
+        if self.local_model_path:
+            result = util.load_local_file(self.local_model_path, constants.PROPERTIES_FILE)
+        else:
+            result = aws.get_s3_object(self.bucket, self.properties_key)
+        return json.loads(result)
 
     def load_properties(self):
         result = aws.get_s3_object(self.bucket, self.properties_key)

--- a/thampi/core/thampi_core.py
+++ b/thampi/core/thampi_core.py
@@ -9,7 +9,7 @@ class Thampi(object):
         self.app = app
         self.project_name = os.environ['PROJECT']
         self.environment = os.environ['STAGE']
-        self.local_model_path = os.environ['LOCAL_MODEL_PATH']
+        self.local_model_path = os.environ.get('LOCAL_MODEL_PATH', None)
         self.bucket = helper.get_bucket(self.environment)
         self.model_key = helper.model_key(self.environment, self.project_name)
         self.properties_key = helper.properties_key(self.environment, self.project_name)

--- a/thampi/lib/util.py
+++ b/thampi/lib/util.py
@@ -59,5 +59,17 @@ def parent_dir(relative_file, level=1):
     return os.path.abspath(os.path.join(os.path.dirname(relative_file), *parent_dots))
 
 
+def load_local_model(model_path, model_file):
+    import pickle
+    with open(os.path.join(model_path, model_file), "rb") as f:
+        model = pickle.load(f)
+
+    return model
+
+
+def load_local_file(path, filename):
+    return open(os.path.join(path, filename), "rb").read()
+
+
 if __name__ == '__main__':
     print(utc_now().isoformat())

--- a/thampi/lib/util.py
+++ b/thampi/lib/util.py
@@ -4,6 +4,7 @@ from collections import ChainMap
 import uuid as u
 import datetime
 import os
+import pickle
 
 
 def filter_in(old_dict: Dict, keys: List[str]):
@@ -60,7 +61,6 @@ def parent_dir(relative_file, level=1):
 
 
 def load_local_model(model_path, model_file):
-    import pickle
     with open(os.path.join(model_path, model_file), "rb") as f:
         model = pickle.load(f)
 


### PR DESCRIPTION
In order to setup a K8 deploy of the PNB prediction server, Devops needs to download the model beforehand and then source the model from a local path passed in as an environment variable