### PR TITLE
[Minor] Exposed ThampiContext object and docs: Tutorial, Classes

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,9 @@ Thampi
    overview
    installation
    tutorial
+   Thampi Model API <thampi_model_api>
    Thampi Local API <thampi_local_api>
+   Thampi Context API <thampi_context_api>
    design
 
 

--- a/docs/source/thampi_context_api.rst
+++ b/docs/source/thampi_context_api.rst
@@ -1,0 +1,6 @@
+Thampi Model API
+=================
+
+.. autoclass:: thampi.core.thampi_core.ThampiContext
+   :members:
+   :undoc-members:

--- a/docs/source/thampi_model_api.rst
+++ b/docs/source/thampi_model_api.rst
@@ -1,0 +1,6 @@
+Thampi Model API
+=================
+
+.. autoclass:: thampi.core.model.Model
+   :members:
+   :undoc-members:

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -9,7 +9,7 @@ Let's create a new project `myproject`. We'll use `scikit-learn` as an example b
 ## Dummy Project
 ### Setup(Pip)
 
-```sh
+```console
 mkdir myproject && cd myproject
 virtualenv -p python3 venv
 source ./venv/bin/activate
@@ -18,6 +18,30 @@ pip install scikit-learn
 pip install numpy
 pip install scipy
 pip freeze > requirements.txt
+```
+
+### Setup(Conda)
+Note: This is one way of creating a conda environment. Please use the conventional way if you are comfortable in that style.
+
+```console
+mkdir myproject && cd myproject
+# Create a  conda environment inside the directory myproject
+conda create --prefix=venv python=3.6.7
+pip install thampi
+pip install scikit-learn
+pip install numpy
+pip install scipy
+```
+
+**IMPORTANT**: `thampi` only supports conda requirements files [crafted by hand](https://conda.io/docs/user-guide/tasks/manage-environments.html#create-env-file-manually). So, let's manually create a requirements file with the above dependencies as shown below and save it as `requirements.txt`. The versions will change but you get the idea.
+
+```
+name: thampi-tutorial
+dependencies:
+  - thampi=0.1.0
+  - numpy=1.15.*
+  - scikit-learn=0.20.0
+  - scipy=1.1.0 
 ```
 
 
@@ -99,7 +123,8 @@ if __name__ == '__main__':
 
 ```
 
-* The above code first trains the `sklearn` model as `knn`. To make the `thampi` web framework send the request data to the model, we wrap `knn` in `ThampiWrapper`, a class which implements the `Model` interface. The data sent to the serving endpoint will be passed by `thampi` to the `predict` method as `args`. Likewise, one can wrap models of other libraries as well.
+* The above code first trains the `sklearn` model as `knn`. To make the `thampi` web framework send the request data to the model, we wrap `knn` in `ThampiWrapper`, a class which implements the `Model` interface. The data sent to the serving endpoint will be passed by `thampi` to the `predict` method as `args`. Likewise, one can wrap models of other libraries as well. Ignore the `context` argument in the `predict` method for now. The `context` object sends in the `Flask` application object(and others in the future) which is probably not required for most of the use cases for now.
+ 
 
 
 And then at the terminal run

--- a/thampi/__init__.py
+++ b/thampi/__init__.py
@@ -1,4 +1,5 @@
 from .core.api import init, serve, predict, info, clean, save
 from .core.model import Model
+from .core.thampi_core import ThampiContext
 
 __version__ = "0.1.0"

--- a/thampi/core/model.py
+++ b/thampi/core/model.py
@@ -4,12 +4,30 @@ from thampi.core.thampi_core import ThampiContext
 
 
 class Model(object):
+    """
+    The Abstract Model class which has to be inherited from by the model wrapper class that you create.
+    """
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def initialize(self, context: ThampiContext) -> None:
+        """
+        This method is called once when AWS Lambda first loads the model. You can override this method to setup up
+        global state(e.g. self.database_connection) which you can access within the `predict` method
+
+        :param context: See documentation for Thampi Context API
+
+        """
         pass
 
     @abc.abstractmethod
     def predict(self, args: Dict, context: ThampiContext) -> Dict:
+        """
+        This method is called when the client hits the predict endpoint.
+
+        :param args: The `data` value sent by the client request is populated here.
+        :param context: See documentation for Thampi Context API
+        :return: Returns a dictionary which is automatically converted to JSON and sent back to the client.
+
+        """
         pass

--- a/thampi/core/thampi_core.py
+++ b/thampi/core/thampi_core.py
@@ -32,8 +32,14 @@ class Thampi(object):
 
 
 class ThampiContext(object):
+    """
+    In most cases, you don't need to access the ThampiContext object. It's mostly here for futureproofing the API.
+    """
     def __init__(self, app):
         self._app = app
 
     def get_app(self):
+        """
+        :return: Returns the Flask App object.
+        """
         return self._app


### PR DESCRIPTION
I added one line of code to `thampi/__init__.py` to expose it in the library interface. Rest is documentation.